### PR TITLE
Fix type of IVennDiagram

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -183,7 +183,7 @@ export interface IStyledSetOverlap extends ISetOverlap {
 }
 
 export interface IVennDiagram {
-  (selection: Selection<HTMLElement, readonly IStyledSetOverlap[], any, unknown>): {
+  (selection: Selection<HTMLElement, readonly IStyledSetOverlap[], any, any>): {
     circles: ISolution;
     textCentres: { [set: string]: IPoint };
     nodes: Selection<SVGGElement, IStyledSetOverlap, any, unknown>;


### PR DESCRIPTION
I am trying to use this library to implement Venn diagram in [Mermaid](https://github.com/mermaid-js/mermaid).

This library works finely, but recent TypeScript compilers are complaining type definitions.

> TS2345: Argument of type IVennDiagram is not assignable to parameter of type
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/cae12b2d-a309-4248-81d1-511161c4ae5c">

This type issue is resolved if I cast it.
It appears that `unknown` does not accept any types, while `any` accepts any types.

